### PR TITLE
table structure reference support

### DIFF
--- a/tests/test_table_range.py
+++ b/tests/test_table_range.py
@@ -19,6 +19,7 @@ class TableRangeTest(testing.XlCalculatorTestCase):
         )
         self.tables = {"MyTable": self.table}
 
+    # Column ranges
     def test_one_column_range(self):
         # Test resolving a single column reference
         result = resolve_table_ranges("MyTable[Col2]", self.tables)
@@ -31,3 +32,20 @@ class TableRangeTest(testing.XlCalculatorTestCase):
     def test_two_column_range(self):
         result = resolve_table_ranges("MyTable[[Col2]:[Col3]]", self.tables)
         self.assertEqual(result, "Sheet1!B2:C5")
+
+    # Item specifiers
+    def test_one_item_specifier(self):
+        result = resolve_table_ranges("MyTable[#Headers]", self.tables)
+        self.assertEqual(result, "Sheet1!A1:C1")
+
+    def test_two_item_specifiers(self):
+        result = resolve_table_ranges("MyTable[[#Headers],[#Data]]", self.tables)
+        self.assertEqual(result, "Sheet1!A1:C5")
+
+    def test_this_row_item_specifier(self):
+        result = resolve_table_ranges("MyTable[[#This Row],[Col1]]", self.tables, "Sheet!E2")
+        self.assertEqual(result, "Sheet1!A2:A2")
+
+    def test_item_specifiers_with_column_range(self):
+        result = resolve_table_ranges("MyTable[[#Headers],[Col1]:[Col3]]", self.tables)
+        self.assertEqual(result, "Sheet1!A1:C1")

--- a/tests/test_table_range.py
+++ b/tests/test_table_range.py
@@ -79,13 +79,17 @@ class TableRangeTest(testing.XlCalculatorTestCase):
 
     # Error cases
     def test_not_a_table_range(self):
-        with self.assertRaises(ValueError):
+        with self.assertRaises(Exception):
             resolve_table_ranges("SheetRefWithBracket[]!A2", self.tables)
+        
+        # External table reference
+        with self.assertRaises(Exception):
+            resolve_table_ranges("[external.xlsx]Sheet1!A1", self.tables)
 
     def test_table_not_found(self):
-        with self.assertRaises(ValueError):
+        with self.assertRaises(Exception):
             resolve_table_ranges("NonExistentTable[Col1]", self.tables)
 
     def test_column_not_found(self):
-        with self.assertRaises(ValueError):
+        with self.assertRaises(Exception):
             resolve_table_ranges("EdgeCaseTable[Col4]", self.tables)

--- a/tests/test_table_range.py
+++ b/tests/test_table_range.py
@@ -1,0 +1,33 @@
+from . import testing
+from xlcalculator.utils import resolve_table_ranges
+from xlcalculator.xltypes import XLTable
+
+# Dummy column class for XLTable columns
+class DummyColumn:
+    def __init__(self, name):
+        self.name = name
+
+class TableRangeTest(testing.XlCalculatorTestCase):
+    def setUp(self):
+        # Create a dummy table with columns and a range
+        self.table = XLTable(
+            name="MyTable",
+            sheet="Sheet1",
+            cell_range="A1:C5",
+            columns=[DummyColumn("Col1"), DummyColumn("Col2"), DummyColumn("Col3")],
+            header_row_count=1
+        )
+        self.tables = {"MyTable": self.table}
+
+    def test_one_column_range(self):
+        # Test resolving a single column reference
+        result = resolve_table_ranges("MyTable[Col2]", self.tables)
+        self.assertEqual(result, "Sheet1!B2:B5")
+
+    def test_empty_bracket_range(self):
+        result = resolve_table_ranges("MyTable[]", self.tables)
+        self.assertEqual(result, "Sheet1!A2:C5")
+
+    def test_two_column_range(self):
+        result = resolve_table_ranges("MyTable[[Col2]:[Col3]]", self.tables)
+        self.assertEqual(result, "Sheet1!B2:C5")

--- a/tests/test_table_range.py
+++ b/tests/test_table_range.py
@@ -2,7 +2,7 @@ from . import testing
 from xlcalculator.utils import resolve_table_ranges
 from xlcalculator.xltypes import XLTable
 
-# Dummy column class for XLTable columns
+# Dummy column class for our ExcelTableColumn
 class DummyColumn:
     def __init__(self, name):
         self.name = name
@@ -61,6 +61,7 @@ class TableRangeTest(testing.XlCalculatorTestCase):
         self.assertEqual(result, "Sheet1!A1:C1")
 
     # Edge cases
+    # Big challenge is to parse the items correctly when it has special characters such as spaces, brackets, colons, etc.
     def test_with_spaces(self):
         result = resolve_table_ranges("MyTable[ [Col2] ]", self.tables)
         self.assertEqual(result, "Sheet1!B2:B5")

--- a/xlcalculator/tokenizer.py
+++ b/xlcalculator/tokenizer.py
@@ -288,7 +288,11 @@ class ExcelParser(ExcelParserTokens):
         token = ""
         inString = False
         inPath = False
+
         inRange = False
+        openBrackets = 0
+        closeBrackets = 0
+
         inError = False
 
         while (len(formula) > 0):
@@ -344,7 +348,12 @@ class ExcelParser(ExcelParserTokens):
             # no embeds (changed to "()" by Excel)
             # end does not mark a token
             if inRange:
-                if currentChar() == "]":
+                # check if bracket is not escaped
+                if currentChar() == "[" and token[-1] != "'":
+                    openBrackets += 1
+                elif currentChar() == "]" and token[-1] != "'":
+                    closeBrackets += 1
+                if openBrackets == closeBrackets:
                     inRange = False
                 token += currentChar()
                 offset += 1
@@ -394,6 +403,7 @@ class ExcelParser(ExcelParserTokens):
                 continue
 
             if (currentChar() == "["):
+                openBrackets += 1
                 inRange = True
                 token += currentChar()
                 offset += 1

--- a/xlcalculator/utils.py
+++ b/xlcalculator/utils.py
@@ -297,14 +297,14 @@ def _get_table_range(table_name: str, start_col: str | None, end_col: str | None
                     coor = cur_cell_addr.rsplit("!", 1)[-1]
                     _, min_row, _, max_row = range_boundaries(coor)
                 case _:
-                    # todo: Totals
+                    # TODO: Totals
                     raise InvalidItemSpecifierError(f"Item specifier not supported yet: {item_specifier}")
     
     # Special case: no column range specified, so span all columns
     if start_col is None:
         return f"{tables[table_name].sheet}!{get_column_letter(min_col)}{min_row}:{get_column_letter(max_col)}{max_row}"
 
-    # get column range indexes from column names, limiting column range
+    # Get column range indexes from column names, limiting column range
     start_col_index = None
     end_col_index = None
     index = min_col
@@ -327,16 +327,6 @@ def _translate_table_name(table_name: str, tables: dict) -> str:
     """
     Since we're appending _<sheet_name> to the table name in the upload code, and while the excel formula still retains the original table name,
     we need to find the table name that matches the original table name.
-    
-    Args:
-        table_name: The original table name to look up
-        tables: Dictionary of available tables
-        
-    Returns:
-        str: The actual table name in the tables dictionary
-        
-    Raises:
-        TableNotFoundError: If the table name cannot be found
     """
     if table_name in tables:
         return table_name

--- a/xlcalculator/utils.py
+++ b/xlcalculator/utils.py
@@ -223,12 +223,12 @@ def _get_table_range(table_name: str, start_col: str | None, end_col: str | None
                 case ItemSpecifier.ThisRow:
                     # min_row = max_row = current row
                     if cur_cell_addr is None:
-                        raise ValueError("Current cell address is not provider for This Row item specifier")
+                        raise ValueError("Current cell address is not provided for #This Row item specifier")
                     coor = cur_cell_addr.rsplit("!", 1)[-1]
                     _, min_row, _, max_row = range_boundaries(coor)
                 case _:
-                    # todo cases: Totals
-                    raise ValueError(f"Item specifier not suppoerted yet: {item_specifier}")
+                    # todo: Totals
+                    raise ValueError(f"Item specifier not supported yet: {item_specifier}")
     
     # special case: no column range specified, so span all columns
     if start_col is None:

--- a/xlcalculator/xltypes.py
+++ b/xlcalculator/xltypes.py
@@ -30,11 +30,6 @@ class XLFormula(XLType):
     def __post_init__(self):
         """Supplimentary initialisation."""
         self.tokens = tokenizer.ExcelParser().getTokens(self.formula).items
-        
-        # Additional support: merge together separated multi comma table specifiers
-        reading_table_range = False
-        table_range_parts = []
-
         for token in self.tokens:
             if (
                     (token.ttype == ExcelParserTokens.TOK_TYPE_OPERAND)
@@ -42,27 +37,7 @@ class XLFormula(XLType):
                     and (token.tvalue not in self.terms)
             ):
                 # Make sure we have a full address.
-                term = token.tvalue
-
-                # combine together separated multi comma table specifiers
-                if not reading_table_range and term.count("[") == 2 and term.count("]") == 1:
-                    reading_table_range = True
-                    table_range_parts.append(term)
-                    continue
-                elif reading_table_range and term.count("[") == 1 and term.count("]") == 1:
-                    table_range_parts.append(term)
-                    continue
-                elif reading_table_range and term == "]":
-                    term = ",".join(table_range_parts)
-                    term += " ]"
-                    reading_table_range = False
-                    table_range_parts = []
-                elif reading_table_range and term.count("[") == 1 and term.count("]") == 2:
-                    table_range_parts.append(term)
-                    term = ",".join(table_range_parts)
-                    reading_table_range = False
-                    table_range_parts = []
-                    
+                term = token.tvalue                    
                 if '!' not in term:
                     term = f'{self.sheet_name}!{term}'
                 self.terms.append(term)

--- a/xlcalculator/xltypes.py
+++ b/xlcalculator/xltypes.py
@@ -102,3 +102,4 @@ class XLTable(XLType):
     cell_range: str = field(default=None)
     columns: list = field(default=None)
     header_row_count: int = field(default=None)
+    has_totals_row: bool = field(default=False)

--- a/xlcalculator/xltypes.py
+++ b/xlcalculator/xltypes.py
@@ -108,7 +108,7 @@ class XLRange(XLType):
     cells: list = field(init=False, compare=True, hash=False, repr=False)
     sheet: str = field(init=False, default="Sheet1", repr=False)
     value: list = field(default=None, repr=True)
-    max_row: int = field(default=None, repr=True)
+    max_row: int | None = field(default=None, repr=True)
 
     def __post_init__(self):
         if self.name is None:

--- a/xlcalculator/xltypes.py
+++ b/xlcalculator/xltypes.py
@@ -30,6 +30,11 @@ class XLFormula(XLType):
     def __post_init__(self):
         """Supplimentary initialisation."""
         self.tokens = tokenizer.ExcelParser().getTokens(self.formula).items
+        
+        # Additional support: merge together separated multi comma table specifiers
+        reading_table_range = False
+        table_range_parts = []
+
         for token in self.tokens:
             if (
                     (token.ttype == ExcelParserTokens.TOK_TYPE_OPERAND)
@@ -38,6 +43,26 @@ class XLFormula(XLType):
             ):
                 # Make sure we have a full address.
                 term = token.tvalue
+
+                # combine together separated multi comma table specifiers
+                if not reading_table_range and term.count("[") == 2 and term.count("]") == 1:
+                    reading_table_range = True
+                    table_range_parts.append(term)
+                    continue
+                elif reading_table_range and term.count("[") == 1 and term.count("]") == 1:
+                    table_range_parts.append(term)
+                    continue
+                elif reading_table_range and term == "]":
+                    term = ",".join(table_range_parts)
+                    term += " ]"
+                    reading_table_range = False
+                    table_range_parts = []
+                elif reading_table_range and term.count("[") == 1 and term.count("]") == 2:
+                    table_range_parts.append(term)
+                    term = ",".join(table_range_parts)
+                    reading_table_range = False
+                    table_range_parts = []
+                    
                 if '!' not in term:
                     term = f'{self.sheet_name}!{term}'
                 self.terms.append(term)

--- a/xlcalculator/xltypes.py
+++ b/xlcalculator/xltypes.py
@@ -93,3 +93,12 @@ class XLRange(XLType):
     @property
     def address(self):
         return self.cells
+
+@dataclass
+class XLTable(XLType):
+    """Excel Table"""
+    name: str = field(default=None)
+    sheet: str = field(default="Sheet1")
+    cell_range: str = field(default=None)
+    columns: list = field(default=None)
+    header_row_count: int = field(default=None)


### PR DESCRIPTION
This PR adds support to resolve table structured references to its cell range.

Example ranges: Table[Column], Table[[#Headers],[Column]], Table[[Col1]:[Col2]]

Updates:
- Added structured reference range resolution support based on the syntax guide. Functions in utils.py
- Slightly modify the terms extraction logic in XLFormula to recombine comma separated identifiers
- Added test cases in test_table_range.py, passing all of them

Structured reference syntax guide: https://support.microsoft.com/en-au/office/using-structured-references-with-excel-tables-f5ed2452-2337-4f71-bed3-c8ae6d2b276e



